### PR TITLE
Update transform_create_populate_tables1.sql

### DIFF
--- a/dev_db/marston/routines/transform_create_populate_tables1.sql
+++ b/dev_db/marston/routines/transform_create_populate_tables1.sql
@@ -49,7 +49,7 @@ BEGIN
 			'caseid', 'caseid', 'caseid'
             ,'caseid', 'caseid' --25
             ,'lacescaseid', 'lacescaseid', 'lacescaseid', 'lacescaseid', 'lacescaseid', 'lacescaseid'
-            ,'experianentryid', 'ExperianEntriesRecordID', 'propertyid', 'landregistryentryid'
+          --  ,'experianentryid', 'ExperianEntriesRecordID', 'propertyid', 'landregistryentryid' -- 26/11/2024: AC - to fix issue on DCES-619
             
         ])
     LOOP


### PR DESCRIPTION
This is to fix the issue observed on DCES-619. Join keys are not needed for the "exception" tables, so removing them. Seems like it'd solved the issue after running a test.