### PR TITLE
Update transform_create_populate_tables1.sql

### DIFF
--- a/dev_db/marston/routines/transform_create_populate_tables1.sql
+++ b/dev_db/marston/routines/transform_create_populate_tables1.sql
@@ -281,6 +281,8 @@ UPDATE transform.laacasedetails
 SET clientcasereference = '6416537'
 WHERE clientcasereference = 'A1043EL';
 
-
+-- DCES-612 // Removing duplicate and incorrect defendants, hardcoding it as this shoudn't happen again
+DELETE FROM transform.laadefaulters
+WHERE defaulterid IN ('13184712', '13203526', '13240529');
 
 END;


### PR DESCRIPTION
As per Observation 151 and the ticket DCES-612, there are 3 defendant records which are incorrectly created by Marston (confirmed by them) that we should be ignoring from data migration. DELETE statement added at the end of the script for that. It is hardcoded as we want to catch if this happens again (new duplication) which shouldn't.