### PR TITLE
Update transform_create_populate_tables1.sql

### DIFF
--- a/dev_db/marston/routines/transform_create_populate_tables1.sql
+++ b/dev_db/marston/routines/transform_create_populate_tables1.sql
@@ -285,4 +285,11 @@ WHERE clientcasereference = 'A1043EL';
 DELETE FROM transform.laadefaulters
 WHERE defaulterid IN ('13184712', '13203526', '13240529');
 
+-- DCES-632 // Populating missing clientdefaulterreference value from maat's extract
+UPDATE transform.laacasedetails a
+SET clientdefaulterreference = (SELECT applid FROM marston.maat_applicantid m
+WHERE m.maatid = a.clientcasereference)
+WHERE (clientdefaulterreference = 'NULL' OR clientdefaulterreference =''
+OR clientdefaulterreference is null);
+
 END;


### PR DESCRIPTION
As per DCES-632, this change is to populate missing clientdefaulterreference fields on casedetails table. The base lookup table will need to be refreshed (from a refresh maat extract) each time before we run this script. But this time it fixes 110 missing records. These are caused by business' manual case creation process, which is informed to them and Joanna is looking at resolving it (with a new excel template).